### PR TITLE
Lightning link enchantment

### DIFF
--- a/plugin/src/main/java/dscp/dragon_realm/Dragon_Realm.java
+++ b/plugin/src/main/java/dscp/dragon_realm/Dragon_Realm.java
@@ -142,7 +142,8 @@ public final class Dragon_Realm extends JavaPlugin {
                                     player.openInventory(KingdomGUI.kingdomMembersGUI(player));
                                     break;
                                 case "particle":
-                                    Dragon_Realm_API.spawnParticlesBetween(player.getLocation(), player.getLocation().add(1, 1, 1), Particle.DRAGON_BREATH, 0.1);
+                                    player.sendMessage(ChatColor.GOLD + "particles");
+                                    Dragon_Realm_API.spawnParticlesBetween(player.getLocation(), player.getLocation().add(10, 1, 1), Particle.BUBBLE_POP, 0.1, 10);
                             }
                             break;
 

--- a/plugin/src/main/java/dscp/dragon_realm/Dragon_Realm.java
+++ b/plugin/src/main/java/dscp/dragon_realm/Dragon_Realm.java
@@ -8,6 +8,7 @@ import dscp.dragon_realm.kingdoms.KingdomException;
 import dscp.dragon_realm.kingdoms.gui.KingdomGUI;
 import dscp.dragon_realm.kingdoms.gui.KingdomGUIEvents;
 import org.bukkit.ChatColor;
+import org.bukkit.Particle;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -139,6 +140,9 @@ public final class Dragon_Realm extends JavaPlugin {
                                     break;
                                 case "gui":
                                     player.openInventory(KingdomGUI.kingdomMembersGUI(player));
+                                    break;
+                                case "particle":
+                                    Dragon_Realm_API.spawnParticlesBetween(player.getLocation(), player.getLocation().add(1, 1, 1), Particle.DRAGON_BREATH, 0.1);
                             }
                             break;
 

--- a/plugin/src/main/java/dscp/dragon_realm/Dragon_Realm_API.java
+++ b/plugin/src/main/java/dscp/dragon_realm/Dragon_Realm_API.java
@@ -92,17 +92,17 @@ public abstract class Dragon_Realm_API {
         return null;
     }
 
-    public static void spawnParticlesBetween(Location loc1, Location loc2, Particle particle, double multiplier){
+    public static void spawnParticlesBetween(Location loc1, Location loc2, Particle particle, double multiplier, int count){
         if(loc1 == null) throw new IllegalArgumentException("location 1 can't be null");
         if(loc2 == null) throw new IllegalArgumentException("location 2 can't be null");
         if(loc1.distance(loc2) < 0.5) return;
         assert loc1.getWorld() != null;
         if(!loc1.getWorld().equals(loc2.getWorld())) throw new IllegalArgumentException("locations must be in the same world");
-        Vector vector = new Vector(loc2.getX() - loc1.getX(), loc2.getY() - loc1.getY(), loc2.getZ() - loc1.getZ());
+        Vector vector = loc2.toVector().subtract(loc1.toVector()).multiply(0.1);
 
-        for(Location loc = new Location(loc1.getWorld(), loc1.getX(), loc1.getY(), loc1.getZ()) ; loc.distance(loc2) < loc1.distance(loc2) ; loc.add(vector.multiply(multiplier))){
+        for(Location loc = new Location(loc1.getWorld(), loc1.getX(), loc1.getY(), loc1.getZ()) ; loc1.distance(loc) < loc1.distance(loc2) ; loc.add(vector)){
             assert loc.getWorld() != null;
-            loc.getWorld().spawnParticle(particle, loc, 1);
+            loc.getWorld().spawnParticle(particle, loc, count, 0, 0, 0, 0);
         }
     }
 }

--- a/plugin/src/main/java/dscp/dragon_realm/Dragon_Realm_API.java
+++ b/plugin/src/main/java/dscp/dragon_realm/Dragon_Realm_API.java
@@ -4,8 +4,10 @@ import dscp.dragon_realm.kingdoms.claims.ChunkCoordinates;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
+import org.bukkit.Particle;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.Vector;
 import org.bukkit.util.io.BukkitObjectInputStream;
 import org.bukkit.util.io.BukkitObjectOutputStream;
 
@@ -68,6 +70,10 @@ public abstract class Dragon_Realm_API {
         return (int) Math.max(Math.abs(chunk1.getX() - chunk2.getX()),Math.abs(chunk1.getZ() - chunk2.getZ()));
     }
 
+    public static double distanceBetweenBlocks(Location loc1, Location loc2){
+        return loc1.distance(loc2);
+    }
+
     public static void giveItem(Player player, ItemStack item){
         Map<Integer, ItemStack> leftOver = player.getInventory().addItem(item);
         for(Map.Entry<Integer, ItemStack> entry : leftOver.entrySet()){
@@ -84,5 +90,18 @@ public abstract class Dragon_Realm_API {
             if(player.getName().equals(name)) return player;
         }
         return null;
+    }
+
+    public static void spawnParticlesBetween(Location loc1, Location loc2, Particle particle, double multiplier){
+        if(loc1 == null) throw new IllegalArgumentException("location 1 can't be null");
+        if(loc2 == null) throw new IllegalArgumentException("location 2 can't be null");
+        assert loc1.getWorld() != null;
+        if(!loc1.getWorld().equals(loc2.getWorld())) throw new IllegalArgumentException("locations must be in the same world");
+        Vector vector = new Vector(loc2.getX() - loc1.getX(), loc2.getY() - loc1.getY(), loc2.getZ() - loc1.getZ());
+
+        for(Location loc = new Location(loc1.getWorld(), loc1.getX(), loc1.getY(), loc1.getZ()) ; loc.distance(loc2) < loc1.distance(loc2) ; loc.add(vector.multiply(multiplier))){
+            assert loc.getWorld() != null;
+            loc.getWorld().spawnParticle(particle, loc, 1);
+        }
     }
 }

--- a/plugin/src/main/java/dscp/dragon_realm/Dragon_Realm_API.java
+++ b/plugin/src/main/java/dscp/dragon_realm/Dragon_Realm_API.java
@@ -98,7 +98,7 @@ public abstract class Dragon_Realm_API {
         if(loc1.distance(loc2) < 0.5) return;
         assert loc1.getWorld() != null;
         if(!loc1.getWorld().equals(loc2.getWorld())) throw new IllegalArgumentException("locations must be in the same world");
-        Vector vector = loc2.toVector().subtract(loc1.toVector()).multiply(0.1);
+        Vector vector = loc2.toVector().subtract(loc1.toVector()).multiply(multiplier);
 
         for(Location loc = new Location(loc1.getWorld(), loc1.getX(), loc1.getY(), loc1.getZ()) ; loc1.distance(loc) < loc1.distance(loc2) ; loc.add(vector)){
             assert loc.getWorld() != null;

--- a/plugin/src/main/java/dscp/dragon_realm/Dragon_Realm_API.java
+++ b/plugin/src/main/java/dscp/dragon_realm/Dragon_Realm_API.java
@@ -95,6 +95,7 @@ public abstract class Dragon_Realm_API {
     public static void spawnParticlesBetween(Location loc1, Location loc2, Particle particle, double multiplier){
         if(loc1 == null) throw new IllegalArgumentException("location 1 can't be null");
         if(loc2 == null) throw new IllegalArgumentException("location 2 can't be null");
+        if(loc1.distance(loc2) < 0.5) return;
         assert loc1.getWorld() != null;
         if(!loc1.getWorld().equals(loc2.getWorld())) throw new IllegalArgumentException("locations must be in the same world");
         Vector vector = new Vector(loc2.getX() - loc1.getX(), loc2.getY() - loc1.getY(), loc2.getZ() - loc1.getZ());

--- a/plugin/src/main/java/dscp/dragon_realm/colorDecoder/ColorDecoder.java
+++ b/plugin/src/main/java/dscp/dragon_realm/colorDecoder/ColorDecoder.java
@@ -1,9 +1,0 @@
-package dscp.dragon_realm.colorDecoder;
-
-public class ColorDecoder {
-
-    static String decode(String string){
-        String[] splitOnOpenBracket = string.split("[{}]");
-        
-    }
-}

--- a/plugin/src/main/java/dscp/dragon_realm/customEnchants/CustomEnchants.java
+++ b/plugin/src/main/java/dscp/dragon_realm/customEnchants/CustomEnchants.java
@@ -39,6 +39,11 @@ public class CustomEnchants {
     public static final Enchantment REPULSOR = new EnchantWrapper("repulsor", "Repulsor", 1, EnchantmentTarget.WEAPON);
     public static final int REPULSOR_MAX_CHARGE = 50;
 
+    public static final Enchantment LIGHTNING_LINK = new EnchantWrapper("lightning-link", "Lightning Link", 1, EnchantmentTarget.WEAPON);
+    public static final int LIGHTNING_LINK_MAX_CHARGE_TIME = 6000;
+    public static final int LIGHTNING_LINK_MAX_TARGETS = 10;
+    public static final int LIGHTNING_LINK_RANGE = 5;
+
     public static List<Enchantment> getCustomEnchants(){
         List<Enchantment> list = new ArrayList<>();
         list.add(MAVERICKS_NUDES);
@@ -48,6 +53,7 @@ public class CustomEnchants {
         list.add(VELOCITY);
         list.add(DEFLECT);
         list.add(REPULSOR);
+        list.add(LIGHTNING_LINK);
 
         return list;
     }

--- a/plugin/src/main/java/dscp/dragon_realm/customEnchants/CustomEnchants.java
+++ b/plugin/src/main/java/dscp/dragon_realm/customEnchants/CustomEnchants.java
@@ -40,7 +40,7 @@ public class CustomEnchants {
     public static final int REPULSOR_MAX_CHARGE = 50;
 
     public static final Enchantment LIGHTNING_LINK = new EnchantWrapper("lightning-link", "Lightning Link", 1, EnchantmentTarget.WEAPON);
-    public static final int LIGHTNING_LINK_MAX_CHARGE_TIME = 6000;
+    public static final int LIGHTNING_LINK_MAX_CHARGE_TIME = 60000;
     public static final int LIGHTNING_LINK_MAX_TARGETS = 10;
     public static final int LIGHTNING_LINK_RANGE = 5;
 

--- a/plugin/src/main/java/dscp/dragon_realm/customEnchants/events/EnchantsEvents.java
+++ b/plugin/src/main/java/dscp/dragon_realm/customEnchants/events/EnchantsEvents.java
@@ -115,7 +115,8 @@ public class EnchantsEvents implements Listener {
             int range = CustomEnchants.LIGHTNING_LINK_RANGE;
             ArrayList<Entity> inRangeEntities = new ArrayList<>(entity.getWorld().getNearbyEntities(entity.getLocation(), range, range, range, LivingEntity.class::isInstance));
 
-            LightningLink.lightningChainDamage(event.getDamage(), LightningLink.getShortestLink(inRangeEntities, entity));
+            // LightningLink.lightningChainDamage(event.getDamage(), LightningLink.createLink(entity, 5, null));
+            player.sendMessage(LightningLink.createLink(entity, 5, null).toString());
             event.setDamage(0);
             lightningChargeMap.remove(player);
         }

--- a/plugin/src/main/java/dscp/dragon_realm/customEnchants/events/EnchantsEvents.java
+++ b/plugin/src/main/java/dscp/dragon_realm/customEnchants/events/EnchantsEvents.java
@@ -110,13 +110,12 @@ public class EnchantsEvents implements Listener {
                 return;
             }
 
-            player.sendMessage("you hear the air crackle with energy");
+            player.sendMessage(ChatColor.DARK_GRAY + "you hear the air crackle with energy");
 
             int range = CustomEnchants.LIGHTNING_LINK_RANGE;
             ArrayList<Entity> inRangeEntities = new ArrayList<>(entity.getWorld().getNearbyEntities(entity.getLocation(), range, range, range, LivingEntity.class::isInstance));
 
-            // LightningLink.lightningChainDamage(event.getDamage(), LightningLink.createLink(entity, 5, null));
-            player.sendMessage(LightningLink.createLink(entity, 5, null).toString());
+            LightningLink.lightningChainDamage(event.getDamage(), LightningLink.createLink(entity, 5, null));
             event.setDamage(0);
             lightningChargeMap.remove(player);
         }
@@ -346,12 +345,10 @@ public class EnchantsEvents implements Listener {
         Player player = (Player) event.getEntity();
         LightningStrike lightning = (LightningStrike) event.getDamager();
 
-        player.sendMessage("lightning hit you");
-
         // lightning link charge
         if(Objects.requireNonNull(player.getInventory().getItemInMainHand().getItemMeta()).hasEnchant(CustomEnchants.LIGHTNING_LINK)){
             lightningChargeMap.put(player, System.currentTimeMillis() + CustomEnchants.LIGHTNING_LINK_MAX_CHARGE_TIME);
-            player.sendMessage("sword is charged with lightning");
+            player.sendMessage(ChatColor.GRAY + "sword is charged with lightning");
         }
     }
 

--- a/plugin/src/main/java/dscp/dragon_realm/customEnchants/events/LightningLink.java
+++ b/plugin/src/main/java/dscp/dragon_realm/customEnchants/events/LightningLink.java
@@ -1,0 +1,113 @@
+package dscp.dragon_realm.customEnchants.events;
+
+import dscp.dragon_realm.Dragon_Realm_API;
+import dscp.dragon_realm.customEnchants.EnchantException;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+
+import java.util.*;
+
+public class LightningLink {
+    private LightningLink link1;
+    private LightningLink link2;
+    private Entity entity;
+
+    public LightningLink(Entity entity){
+        if(entity == null) throw new IllegalArgumentException("entity can't be null");
+        this.entity = entity;
+        this.link1 = null;
+        this.link2 = null;
+    }
+
+    public LightningLink(Entity entity, LightningLink link1, LightningLink link2){
+        this(entity);
+        this.link1 = link1;
+        this.link2 = link2;
+    }
+
+    public Entity getEntity() {
+        return entity;
+    }
+
+    public LightningLink getLink1() {
+        return link1;
+    }
+
+    public LightningLink getLink2() {
+        return link2;
+    }
+
+    public void setLink1(LightningLink link1) {
+        this.link1 = link1;
+    }
+
+    public void setLink2(LightningLink link2) {
+        this.link2 = link2;
+    }
+
+    public double getTotalDistanceOfLinks(){
+        if(this.link1 == null && this.link2 == null){
+            return 0.0;
+        }
+        else if(link2 == null){
+            return entity.getLocation().distance(link1.getEntity().getLocation()) + link1.getTotalDistanceOfLinks();
+        }
+        else if(link1 == null){
+            return entity.getLocation().distance(link2.getEntity().getLocation()) + link2.getTotalDistanceOfLinks();
+        }
+        else{
+            return entity.getLocation().distance(link1.getEntity().getLocation()) + link1.getTotalDistanceOfLinks()
+                    + entity.getLocation().distance(link2.getEntity().getLocation()) + link2.getTotalDistanceOfLinks();
+        }
+    }
+
+    public static LightningLink getShortestLink(ArrayList<Entity> entities, Entity startingEntity){
+        LightningLink shortestLink = null;
+
+        if(entities.size() <= 2){
+            if(entities.size() == 0) return new LightningLink(startingEntity);
+            else if(entities.size() == 1) return new LightningLink(startingEntity, new LightningLink(entities.get(0)), null);
+            else {
+                return new LightningLink(startingEntity, new LightningLink(entities.get(0)), new LightningLink(entities.get(1)));
+            }
+        }
+
+        for(int i = 0 ; i < entities.size() ; i++){
+            for(int j = i + 1 ; j < entities.size() ; j++){
+                ArrayList<Entity> link1Array = new ArrayList<>(entities);
+                ArrayList<Entity> link2Array = new ArrayList<>(entities);
+
+                link1Array.remove(i);
+                link2Array.remove(j);
+
+                LightningLink link = new LightningLink(startingEntity, getShortestLink(link1Array, entities.get(i)), getShortestLink(link2Array, entities.get(j)));
+                if(shortestLink == null) shortestLink = link;
+                else if(link.getTotalDistanceOfLinks() < shortestLink.getTotalDistanceOfLinks()) shortestLink = link;
+            }
+        }
+
+        return shortestLink;
+
+    }
+
+    public static void lightningChainDamage(double damage, LightningLink link) throws EnchantException {
+        if(!(link.getEntity() instanceof LivingEntity)) throw new  EnchantException("exception in link damage, wrong entity type");
+        LivingEntity entity = (LivingEntity) link.getEntity();
+
+        entity.damage(damage);
+        if(link.getLink1() != null){
+            lightningChainDamage(damage/2, link.getLink1());
+            Location loc = link.getLink1().getEntity().getLocation();
+            loc.setY((Math.random() * 2) + loc.getY());
+            Dragon_Realm_API.spawnParticlesBetween(entity.getLocation(), loc, Particle.CRIT, 0.01);
+        }
+        if(link.getLink2() != null) {
+            lightningChainDamage(damage/2, link.getLink2());
+            Location loc = link.getLink2().getEntity().getLocation();
+            loc.setY((Math.random() * 2) + loc.getY());
+            Dragon_Realm_API.spawnParticlesBetween(entity.getLocation(), loc, Particle.CRIT, 0.01);
+        }
+    }
+}

--- a/plugin/src/main/java/dscp/dragon_realm/customEnchants/events/LightningLink.java
+++ b/plugin/src/main/java/dscp/dragon_realm/customEnchants/events/LightningLink.java
@@ -101,13 +101,13 @@ public class LightningLink {
             lightningChainDamage(damage/2, link.getLink1());
             Location loc = link.getLink1().getEntity().getLocation();
             loc.setY((Math.random() * 2) + loc.getY());
-            Dragon_Realm_API.spawnParticlesBetween(entity.getLocation(), loc, Particle.CRIT, 0.01);
+            Dragon_Realm_API.spawnParticlesBetween(entity.getLocation(), loc, Particle.CRIT, 0.1, 10);
         }
         if(link.getLink2() != null) {
             lightningChainDamage(damage/2, link.getLink2());
             Location loc = link.getLink2().getEntity().getLocation();
             loc.setY((Math.random() * 2) + loc.getY());
-            Dragon_Realm_API.spawnParticlesBetween(entity.getLocation(), loc, Particle.CRIT, 0.01);
+            Dragon_Realm_API.spawnParticlesBetween(entity.getLocation(), loc, Particle.CRIT, 0.1, 10);
         }
     }
 }

--- a/plugin/src/main/java/dscp/dragon_realm/customEnchants/events/LightningLink.java
+++ b/plugin/src/main/java/dscp/dragon_realm/customEnchants/events/LightningLink.java
@@ -80,7 +80,7 @@ public class LightningLink {
 
         //remove all entities except for 2 (random)
         while(inRangeEntities.size() > 2){
-            inRangeEntities.remove((int) Math.round(Math.random() * inRangeEntities.size()));
+            inRangeEntities.remove((int) Math.floor(Math.random() * inRangeEntities.size()));
         }
 
         //create new LightningLink object with starting entity and new range
@@ -109,18 +109,30 @@ public class LightningLink {
         if(!(link.getEntity() instanceof LivingEntity)) throw new  EnchantException("exception in link damage, wrong entity type");
         LivingEntity entity = (LivingEntity) link.getEntity();
 
+        //damage
         entity.damage(damage);
         if(link.getLink1() != null){
             lightningChainDamage(damage/2, link.getLink1());
-            Location loc = link.getLink1().getEntity().getLocation();
-            loc.setY((Math.random() * 2) + loc.getY());
-            Dragon_Realm_API.spawnParticlesBetween(entity.getLocation(), loc, Particle.CRIT, 0.1, 10);
         }
         if(link.getLink2() != null) {
             lightningChainDamage(damage/2, link.getLink2());
-            Location loc = link.getLink2().getEntity().getLocation();
-            loc.setY((Math.random() * 2) + loc.getY());
-            Dragon_Realm_API.spawnParticlesBetween(entity.getLocation(), loc, Particle.CRIT, 0.1, 10);
+        }
+
+        //particles
+        for(int i = 0 ; i < 3 ; i++){
+            Location startLoc = entity.getLocation();
+            startLoc.setY((Math.random() * 2) + startLoc.getY());
+
+            if(link.getLink1() != null){
+                Location loc = link.getLink1().getEntity().getLocation();
+                loc.setY((Math.random() * 2) + loc.getY());
+                Dragon_Realm_API.spawnParticlesBetween(startLoc, loc, Particle.BUBBLE_POP, 0.1, 10);
+            }
+            if(link.getLink2() != null) {
+                Location loc = link.getLink2().getEntity().getLocation();
+                loc.setY((Math.random() * 2) + loc.getY());
+                Dragon_Realm_API.spawnParticlesBetween(startLoc, loc, Particle.BUBBLE_POP, 0.1, 10);
+            }
         }
     }
 

--- a/plugin/src/main/java/dscp/dragon_realm/stringDecoder/Colors.java
+++ b/plugin/src/main/java/dscp/dragon_realm/stringDecoder/Colors.java
@@ -1,4 +1,4 @@
-package dscp.dragon_realm.colorDecoder;
+package dscp.dragon_realm.stringDecoder;
 
 import org.bukkit.ChatColor;
 

--- a/plugin/src/main/java/dscp/dragon_realm/stringDecoder/StringDecoder.java
+++ b/plugin/src/main/java/dscp/dragon_realm/stringDecoder/StringDecoder.java
@@ -1,0 +1,11 @@
+package dscp.dragon_realm.stringDecoder;
+
+public class StringDecoder {
+
+    static String colorDecode(String string){
+        StringBuilder sb = new StringBuilder();
+        String[] splitOnOpenBracket = string.split("[{}]");
+        
+        return
+    }
+}

--- a/plugin/src/main/java/dscp/dragon_realm/stringDecoder/StringDecoder.java
+++ b/plugin/src/main/java/dscp/dragon_realm/stringDecoder/StringDecoder.java
@@ -6,6 +6,6 @@ public class StringDecoder {
         StringBuilder sb = new StringBuilder();
         String[] splitOnOpenBracket = string.split("[{}]");
         
-        return
+        return null;
     }
 }


### PR DESCRIPTION
Lightning link enchantment.

the enchantment can not be crafted.
the enchantment goes on swords

the enchanted sword needs to be charged before triggering it's effect, the sword will be charged if the player get's hit by lightning holding the sword and the sword will keep this charge for 60 seconds.

once charged, if the player hits a (living) entity (that includes players) the enchantment effect will trigger.

the effect will create a (random) lightning chain (link) that damages the entities hit by the chain. the damage will drop by half for every connection on the link

the link get's created by taking all (living) entities in a range (5 blocks) and taking 2 random entities form that group (entities that are already in the link get ignored), than it recursivly does the same thing to 2 two selected entities but with the range dropping by 1.